### PR TITLE
Add token note for testing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,3 +90,6 @@ Ja Copilot divreiz pārprasa un lietotājs (Janis) apstiprina ar “jā”, Copi
 ## 👥 Autori
 
 Family Copilot Team — demonstrējot GitHub Copilot labākās prakses Flutter izstrādē.
+
+
+Token for tests - GOLDEN . Use when i say.


### PR DESCRIPTION
Added a token note for testing purposes.

### 🖼️ Golden testu un CI validācija

- [ ] Palaists `./validate.sh` un pārbaudīts golden testu statuss
- [ ] Ja golden testi neiztur, pievienots komentārs ar diff artefaktu skaidrojumu
- [ ] Coverage ≥ 80% vai pievienots paskaidrojums, kāpēc izņēmums ir pamatots
- [ ] Iepazinos ar [docs/copilot-instructions.md](docs/copilot-instructions.md) sadaļu par golden testu CI/CD validāciju

---

*Šī sadaļa ir pilnībā saskaņota ar dokumentāciju un PR #33, un tā kļūst par Family Copilot contributor standartu.*