### PR TITLE
Update copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -86,10 +86,13 @@ Lai pārbaudītu testu pārklājumu, golden struktūru un CI statusu, palaidiet:
 Ja Copilot divreiz pārprasa un lietotājs (Janis) apstiprina ar “jā”, Copilot drīkst pārkāpt kādu no iepriekš minētajiem ierobežojumiem konkrētajā kontekstā. Šis izņēmums attiecas tikai uz interaktīvu sesiju ar Janis, un tas nedrīkst tikt izmantots automātiski vai bez skaidras apstiprināšanas.
 
 ---
-
 ## 👥 Autori
 
-Family Copilot Team — demonstrējot GitHub Copilot labākās prakses Flutter izstrādē.
+**Family Copilot Team** — demonstrējot GitHub Copilot labākās prakses Flutter izstrādē, tostarp reproducējamu CI/CD validāciju, golden testu struktūru un contributor-first dokumentāciju.
 
+---
 
-Token for tests - GOLDEN . Use when i say.
+**Token for tests:** `GOLDEN`  
+Šo tokenu izmanto golden testu aktivizēšanai, kad tas tiek norādīts.  
+_Use this token to activate golden test logic when explicitly instructed._
+


### PR DESCRIPTION
### 🖼️ Golden testu un CI validācija

- [ ] Palaists `./validate.sh` un pārbaudīts golden testu statuss
- [ ] Ja golden testi neiztur, pievienots komentārs ar diff artefaktu skaidrojumu
- [ ] Coverage ≥ 80% vai pievienots paskaidrojums, kāpēc izņēmums ir pamatots
- [ ] Iepazinos ar [docs/copilot-instructions.md](docs/copilot-instructions.md) sadaļu par golden testu CI/CD validāciju

---

*Šī sadaļa ir pilnībā saskaņota ar dokumentāciju un PR #33, un tā kļūst par Family Copilot contributor standartu.*